### PR TITLE
feat: replace asdf with mise for version management

### DIFF
--- a/dotfiles.d/.bashrc.d/main.bash
+++ b/dotfiles.d/.bashrc.d/main.bash
@@ -35,9 +35,7 @@ export LIBGL_ALWAYS_INDIRECT=true
 eval "$(anyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 eval "$(direnv hook bash)"
-
-export ASDF_DATA_DIR="$HOME/.asdf"
-export PATH="$ASDF_DATA_DIR/shims:$PATH"
+eval "$(mise activate bash)"
 
 # User specific aliases and functions
 alias ls='ls --color=auto'


### PR DESCRIPTION
Remove asdf configuration and initialization, replacing it with mise for consistent tooling across machines. This simplifies the version manager setup by using a single tool for all runtime versions.

- Remove ASDF_DATA_DIR export and PATH configuration
- Add mise bash activation