### PR TITLE
feat(gitconfig): add cleanup alias for pruning remote and merged branches

### DIFF
--- a/dotfiles.d/.gitconfig.d/main.gitconfig
+++ b/dotfiles.d/.gitconfig.d/main.gitconfig
@@ -11,6 +11,7 @@
   pl = pull
   cwb = rev-parse --abbrev-ref HEAD
   add-x = update-index --add --chmod=+x
+  cleanup = "!git remote prune origin && git branch --merged | grep -v '\\*\\|main\\|master' | xargs -n 1 git branch -d"
 
 [color]
   ui = auto


### PR DESCRIPTION
Adds a new git alias 'cleanup' that automates the removal of stale
remote-tracking branches and deletes local branches that have been
merged into main/master. This improves repository hygiene and reduces
clutter in the branch list.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
