### PR TITLE
feat(shell): copilot の 'ask' エイリアスを追加

### DIFF
--- a/dotfiles.d/.bashrc.d/main.bash
+++ b/dotfiles.d/.bashrc.d/main.bash
@@ -22,6 +22,9 @@ PATH="$HOME/.local/lib/shellspec/bin:$PATH"
 
 export PATH
 
+export LC_ALL=ja_JP.UTF-8
+export LANG=ja_JP.UTF-8
+
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
@@ -50,6 +53,7 @@ abbrev-alias -ge B='$(git symbolic-ref --short HEAD 2>/dev/null)'
 abbrev-alias -c automerge='git push origin HEAD && gh pr-create --fill --draft && gh pr ready && gh pr-merge-personal && { git switch main || git switch master; } && git pull'
 abbrev-alias -c awscopilot='/usr/local/bin/copilot'
 abbrev-alias -c copilot='copilot --banner'
+abbrev-alias -c ask='copilot --model gpt-5-mini --prompt'
 abbrev-alias -c cdp='cd $(ls | peco)'
 abbrev-alias -c histp='$($(history | peco || echo ''))'
 

--- a/dotfiles.d/.gitconfig.d/main.gitconfig
+++ b/dotfiles.d/.gitconfig.d/main.gitconfig
@@ -31,3 +31,9 @@
 
 [pull]
   rebase = false
+[credential "https://github.com"]
+	helper = 
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = 
+	helper = !/usr/bin/gh auth git-credential


### PR DESCRIPTION
主な変更点:
- copilot の短縮エイリアス `ask` を追加（copilot --model gpt-5-mini --prompt を呼び出す）
- システムロケールを ja_JP.UTF-8 に設定
- Git の credential helper を gh auth に切り替える設定を追加

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
