### PR TITLE
fix(git): reset inherited credential helpers before declaring gh

### DIFF
--- a/dotfiles.d/.gitconfig.d/main.gitconfig
+++ b/dotfiles.d/.gitconfig.d/main.gitconfig
@@ -32,8 +32,12 @@
 [pull]
   rebase = false
 
+# An empty `helper` discards helpers defined earlier, such as the
+# version-pinned absolute paths `gh auth setup-git` writes into .gitconfig.local
 [credential "https://github.com"]
-	helper = !gh auth git-credential
+  helper =
+  helper = !gh auth git-credential
 [credential "https://gist.github.com"]
-	helper = !gh auth git-credential
+  helper =
+  helper = !gh auth git-credential
 


### PR DESCRIPTION
`gh auth setup-git` writes version-pinned absolute paths for the mise-managed gh binary into the untracked .gitconfig.local, which is pulled in by the [include] near the top of this file. Those paths break on every gh upgrade and git prints "gh: not found" on each push before falling back to a working helper.

credential.helper is multi-valued and git runs every configured helper in order, so declaring the correct one here was not enough. Prepend an empty `helper =` to discard everything inherited from the include, leaving only the PATH-resolved `!gh auth git-credential`, which carries no version number.